### PR TITLE
fix missing async keyword

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,7 +66,7 @@ module.exports = (config) => {
   let currentMetaSteps = [];
 
 
-  event.dispatcher.on(event.all.before, () => {
+  event.dispatcher.on(event.all.before, async () => {
     launchObj = startLaunch();
     try {
       await launchObj.promise;


### PR DESCRIPTION
Fix error:
```
Could not load plugin reportportal from module '@reportportal/agent-js-codecept':
await is only valid in async function
```