### PR TITLE
fix iterateMetaSteps

### DIFF
--- a/index.js
+++ b/index.js
@@ -352,7 +352,7 @@ function metaStepsToArray(step) {
 }
 
 function iterateMetaSteps(step, fn) {
-  if (step.metaStep) iterateMetaSteps(step.metaStep, fn);
+  if (step && step.metaStep) iterateMetaSteps(step.metaStep, fn);
   if (step) fn(step);
 }
 


### PR DESCRIPTION
I have this error when trying the plugin:
"Cannot read property 'metaStep' of undefined"

The fix is easy enough.