### PR TITLE
feat: use the supported reportportal client

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const RPClient = require('reportportal-client');
+const RPClient = require('@reportportal/client-javascript');
 const fs = require('fs');
 const path = require('path');
 const debug = require('debug')('codeceptjs:reportportal');

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "homepage": "https://github.com:reportportal/agent-js-codecept#readme",
   "main": "index.js",
   "dependencies": {
-    "reportportal-client": "5.5.0"
+    "@reportportal/client-javascript": "^5.0.2"
   },
   "scripts": {
     "test": "mocha test/acceptance_test.js --timeout 6000"


### PR DESCRIPTION
https://www.npmjs.com/package/reportportal-client is deprecated and replace by https://www.npmjs.com/package/@reportportal/client-javascript