### PR TITLE
Support parallel execution and fix issue with testcase stats not available

### DIFF
--- a/index.js
+++ b/index.js
@@ -233,7 +233,7 @@ module.exports = (config) => {
         status: suiteStatus,
       }).promise;
     }
-    await finishLaunch();
+    if (!process.env.RP_LAUNCH_ID) await finishLaunch();
   });
 
   function startLaunch(suiteTitle) {
@@ -244,13 +244,19 @@ module.exports = (config) => {
       debug: config.debug,
     });
 
-    return rpClient.startLaunch({
+    const options = {
       name: config.launchName || suiteTitle,
       description: config.launchDescription,
       attributes: config.launchAttributes,
       rerun: config.rerun,
       rerunOf: config.rerunOf,
-    });
+    }
+
+    if (process.env.RP_LAUNCH_ID) { 
+      options.id = process.env.RP_LAUNCH_ID
+    }
+
+    return rpClient.startLaunch(options);
   }
 
   async function attachScreenshot() {

--- a/index.js
+++ b/index.js
@@ -102,7 +102,7 @@ module.exports = (config) => {
 
   event.dispatcher.on(event.suite.before, (suite) => {
     recorder.add(async () => {
-      suiteObj = startTestItem(suite.title, rp_SUITE);
+      suiteObj = startTestItem(suite.title, rp_TEST);
       debug(`${suiteObj.tempId}: The suiteId '${suite.title}' is started.`);
       suite.tempId = suiteObj.tempId;
       suiteStatus = rp_PASSED;
@@ -113,7 +113,7 @@ module.exports = (config) => {
     recorder.add(async () => {
       currentMetaSteps = [];
       stepObj = null;
-      testObj = startTestItem(test.title, rp_TEST, suiteObj.tempId);
+      testObj = startTestItem(test.title, rp_STEP, suiteObj.tempId, true);
       test.tempId = testObj.tempId;
       failedStep = null;
       debug(`${testObj.tempId}: The testId '${test.title}' is started.`);
@@ -211,9 +211,9 @@ module.exports = (config) => {
     });
   });
 
-  function startTestItem(testTitle, method, parentId = null) {
+  function startTestItem(testTitle, method, parentId = null, stats = null) {
     try {
-      const hasStats = method !== rp_STEP;
+      const hasStats = stats || (method !== rp_STEP);
       return rpClient.startTestItem({
         name: testTitle,
         type: method,
@@ -322,7 +322,7 @@ module.exports = (config) => {
       metaStepObj = currentMetaSteps[i-1] || metaStepObj;
 
       const isNested = !!metaStepObj.tempId;
-      metaStepObj = startTestItem(metaStep.toString(), rp_STEP, metaStepObj.tempId || testObj.tempId);
+      metaStepObj = startTestItem(metaStep.toString(), rp_STEP , metaStepObj.tempId || testObj.tempId, false);
       metaStep.tempId = metaStepObj.tempId;
       debug(`${metaStep.tempId}: The stepId '${metaStep.toString()}' is started. Nested: ${isNested}`);
     }


### PR DESCRIPTION
This PR addresses below issues:

## Parallel Execution:

Running codecept tests in parallel using `run-multiple` or `run-workers` creates a new launch for each child process. With this approach test config can implement  bootstrapAll and teardownAll functions to create a launch and pass the launch id to child processes and env variable as shown below:

```
bootstrapAll: async () => {
       const launchId = await startLaunch(config)
       process.env.RP_LAUNCH_ID = launchId
    },
      teardownAll: async () => {
      await finishLaunch()
    }
```
## Testcase widget issues

Reportportal widgets like `Most time consuming tests` , `Flaky tests table` do not render any data. This is because all the nested steps are published with `hasStats=false` . In-order to get test or BDD scenario level stats, reportportal expects a  `Test` -> `Step` -> `Nested Step` structure. Updated the events to follow this structure.

