### PR TITLE
Added 'mode' parameter support for plugin config

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ To use this plugin you need to provide the following info:
 - `launchAttributes`: (optional) the attributes of your launch, if not provided, the attributes will be empty
 - `debug`: (optional) to turn on the debug for reportportal
 - `rerun`: (optional) to enable [rerun](https://github.com/reportportal/documentation/blob/master/src/md/src/DevGuides/rerun.md)
-- `rerunOf`: (optional) UUID of launch you want to rerun. If not specified, report portal will update the latest launch with the same name.
+- `rerunOf`: (optional) UUID of launch you want to rerun. If not specified, report portal will update the latest launch with the same name
+- `mode`: (optional) to specify visibility of launch, if set to 'DEBUG', then run results will be only visible in 'Debug' section of the project.
 
 ## Public API
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ To use this plugin you need to provide the following info:
 - `debug`: (optional) to turn on the debug for reportportal
 - `rerun`: (optional) to enable [rerun](https://github.com/reportportal/documentation/blob/master/src/md/src/DevGuides/rerun.md)
 - `rerunOf`: (optional) UUID of launch you want to rerun. If not specified, report portal will update the latest launch with the same name
-- `mode`: (optional) to specify visibility of launch, if set to 'DEBUG', then run results will be only visible in 'Debug' section of the project.
+- `mode`: (optional) to specify visibility of launch, if set to 'DEBUG', then launch results will be only visible in 'Debug' section of a project.
 
 ## Public API
 

--- a/index.js
+++ b/index.js
@@ -38,7 +38,8 @@ const defaultConfig = {
   attributes: [],
   debug: false,
   rerun: undefined,
-  enabled: false
+  enabled: false,
+  mode: 'DEFAULT'
 };
 
 const requiredFields = ['projectName', 'token', 'endpoint'];
@@ -250,6 +251,7 @@ module.exports = (config) => {
       attributes: config.launchAttributes,
       rerun: config.rerun,
       rerunOf: config.rerunOf,
+      mode: config.mode,
     }
 
     if (process.env.RP_LAUNCH_ID) { 


### PR DESCRIPTION
There are a 'mode' parameter available for start launch request to define whether to show launch in 'Launches' section of RP project  (when set to 'DEFAULT') or in 'Debug' section (when set to 'DEBUG').

Adding support for such parameter.