### PR TITLE
Add deep clone to metaSteps (#12)

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ const fs = require('fs');
 const path = require('path');
 const debug = require('debug')('codeceptjs:reportportal');
 const { event, recorder, output, container } = codeceptjs;
+const deepClone = require('lodash.clonedeep');
 
 const helpers = container.helpers();
 let helper;
@@ -327,7 +328,7 @@ module.exports = (config) => {
       debug(`${metaStep.tempId}: The stepId '${metaStep.toString()}' is started. Nested: ${isNested}`);
     }
 
-    currentMetaSteps = metaSteps;
+    currentMetaSteps = deepClone(metaSteps);
     return currentMetaSteps[currentMetaSteps.length - 1] || testObj;
   }
 

--- a/package.json
+++ b/package.json
@@ -27,11 +27,12 @@
     "test": "mocha test/acceptance_test.js --timeout 6000"
   },
   "devDependencies": {
-    "codeceptjs": "2.5.0",    
     "chai": "^4.2.0",
+    "codeceptjs": "2.5.0",
     "eslint": "^6.6.0",
     "eslint-config-airbnb-base": "^14.0.0",
     "eslint-plugin-import": "^2.18.2",
+    "lodash": "^4.17.21",
     "mocha": "^7.0.1",
     "puppeteer": "^2.1.1"
   }


### PR DESCRIPTION
As codeceptjs works on the metaStep object in the background it happens
temporarily that the metaStep looses the success or failed status.
It has the status "queued" then. This leads to errors on the
http request to reportportal, which cannot handle the status "queued".

With the deepClone the metaStep in the reporter is uncoupled
from codeceptjs and the metaStep manipulation is persistent for the reporter.